### PR TITLE
Add formula selection option

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -39,7 +39,14 @@
                         <button class="btn btn-primary btn-block" id="startAnimation">Start Animation</button>
                         <button class="btn btn-secondary btn-block" id="stopAnimation">Stop Animation</button>
                         <button class="btn btn-danger btn-block" id="reset">Reset</button>
-                        <button class="btn btn-info btn-block" id="toggleJuliaButton">Toggle Julia Mode</button>
+                        <div class="form-group mt-2">
+                            <label for="fractalType">Fractal Type:</label>
+                            <select class="form-control" id="fractalType">
+                                <option value="mandelbrot">Mandelbrot</option>
+                                <option value="julia">Julia</option>
+                                <option value="burningShip">Burning Ship</option>
+                            </select>
+                        </div>
                         <button class="btn btn-warning btn-block" id="fullScreenButton">Toggle Full-Screen</button>
                         <button class="btn btn-dark btn-block" id="darkModeButton">Toggle Dark/Light Mode</button>
                     </div>

--- a/MandelbrotWorker.js
+++ b/MandelbrotWorker.js
@@ -1,5 +1,5 @@
 self.addEventListener("message", (e) => {
-    const { width, height, zoom, offsetX, offsetY, maxIterations, juliaMode, juliaC, colorScheme, invertColors } = e.data;
+    const { width, height, zoom, offsetX, offsetY, maxIterations, fractalType, juliaC, colorScheme, invertColors } = e.data;
     const imageData = new Uint8ClampedArray(width * height * 4);
 
     for (let px = 0; px < width; px++) {
@@ -11,16 +11,26 @@ self.addEventListener("message", (e) => {
             let y = y0;
             let iteration = 0;
 
-            if (juliaMode) {
+            if (fractalType === 'julia') {
                 // Use Julia constant
                 x0 = juliaC.x;
                 y0 = juliaC.y;
             }
 
             while (x * x + y * y <= 4 && iteration < maxIterations) {
-                const tempX = x * x - y * y + x0;
-                y = 2 * x * y + y0;
-                x = tempX;
+                let tempX;
+                switch (fractalType) {
+                    case 'burningShip':
+                        tempX = x * x - y * y + x0;
+                        y = 2 * Math.abs(x * y) + y0;
+                        x = Math.abs(tempX);
+                        break;
+                    default:
+                        tempX = x * x - y * y + x0;
+                        y = 2 * x * y + y0;
+                        x = tempX;
+                        break;
+                }
                 iteration++;
             }
 

--- a/Script.js
+++ b/Script.js
@@ -6,7 +6,7 @@ const invertColorsCheckbox = document.getElementById("invertColors");
 const startAnimationButton = document.getElementById("startAnimation");
 const stopAnimationButton = document.getElementById("stopAnimation");
 const resetButton = document.getElementById("reset");
-const toggleJuliaButton = document.getElementById("toggleJuliaButton");
+const fractalTypeSelect = document.getElementById("fractalType");
 
 let maxIterations = parseInt(iterationsInput.value);
 let zoom = 1;
@@ -16,7 +16,7 @@ let colorScheme = colorSchemeSelect.value;
 let invertColors = false;
 let animationId;
 let isAnimating = false;
-let juliaMode = false;
+let fractalType = fractalTypeSelect.value;
 let juliaC = { x: -0.7, y: 0.27015 };
 
 // Initialize Web Worker only once
@@ -35,7 +35,7 @@ function drawMandelbrotWithWorker() {
         offsetX: offsetX,
         offsetY: offsetY,
         maxIterations: maxIterations,
-        juliaMode: juliaMode,
+        fractalType: fractalType,
         juliaC: juliaC,
         colorScheme: colorScheme,
         invertColors: invertColors
@@ -95,9 +95,9 @@ invertColorsCheckbox.addEventListener("change", () => {
     drawMandelbrotWithWorker();
 });
 
-toggleJuliaButton.addEventListener("click", () => {
+fractalTypeSelect.addEventListener("change", () => {
+    fractalType = fractalTypeSelect.value;
     stopAnimation();
-    juliaMode = !juliaMode;
     drawMandelbrotWithWorker();
 });
 
@@ -107,7 +107,8 @@ resetButton.addEventListener("click", () => {
     zoom = 1;
     offsetX = -0.5;
     offsetY = 0;
-    juliaMode = false;
+    fractalType = 'mandelbrot';
+    fractalTypeSelect.value = 'mandelbrot';
     drawMandelbrotWithWorker();
 });
 


### PR DESCRIPTION
## Summary
- replace Julia toggle with dropdown to choose fractal type
- update main script to send selected type to the worker
- extend worker to support Mandelbrot, Julia, and Burning Ship formulas

## Testing
- `node --check Script.js MandelbrotWorker.js`


------
https://chatgpt.com/codex/tasks/task_e_6843843d56208333bf8cd89e64c9753c