### PR TITLE
Add HSV color mode

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -29,6 +29,7 @@
                             <option value="cool">Cool</option>
                             <option value="fire">Fire</option>
                             <option value="ocean">Ocean</option>
+                            <option value="hsv">HSV</option>
                         </select>
                         <div class="form-check mt-2">
                             <input class="form-check-input" type="checkbox" id="invertColors">

--- a/MandelbrotWorker.js
+++ b/MandelbrotWorker.js
@@ -67,6 +67,9 @@ function getColor(ratio, iteration, maxIterations, colorScheme, invertColors) {
                 g = Math.floor(255 * Math.pow(ratio, 0.3));
                 b = Math.floor(255 * ratio);
                 break;
+            case 'hsv':
+                [r, g, b] = hsvToRgb(ratio, 1, 1).map(v => Math.floor(v * 255));
+                break;
             case 'monochrome':
             default:
                 const shade = Math.floor(255 * ratio);
@@ -84,5 +87,29 @@ function getColor(ratio, iteration, maxIterations, colorScheme, invertColors) {
         b = 255 - b;
     }
 
+    return [r, g, b];
+}
+
+function hsvToRgb(h, s, v) {
+    let r, g, b;
+    const i = Math.floor(h * 6);
+    const f = h * 6 - i;
+    const p = v * (1 - s);
+    const q = v * (1 - f * s);
+    const t = v * (1 - (1 - f) * s);
+    switch (i % 6) {
+        case 0:
+            r = v; g = t; b = p; break;
+        case 1:
+            r = q; g = v; b = p; break;
+        case 2:
+            r = p; g = v; b = t; break;
+        case 3:
+            r = p; g = q; b = v; break;
+        case 4:
+            r = t; g = p; b = v; break;
+        case 5:
+            r = v; g = p; b = q; break;
+    }
     return [r, g, b];
 }


### PR DESCRIPTION
## Summary
- extend the color scheme dropdown with HSV option
- implement HSV color calculation in the Mandelbrot worker

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6843843f4d7483338ca8489dfeaa8985