### PR TITLE
Add error handling for worker initialization

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -43,6 +43,9 @@
                         <button class="btn btn-warning btn-block" id="fullScreenButton">Toggle Full-Screen</button>
                         <button class="btn btn-dark btn-block" id="darkModeButton">Toggle Dark/Light Mode</button>
                     </div>
+                    <div id="workerError" class="alert alert-danger mt-2 d-none" role="alert">
+                        Failed to load the Mandelbrot worker.
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- handle Web Worker initialization errors in `Script.js`
- show an alert in the UI when the worker fails to load

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68438437e7ac8333a21a2defe4a6131b